### PR TITLE
Simplify: fix correctness bugs, dead code, and efficiency issues

### DIFF
--- a/src/chainlink/cleaning/cleaning_functions.py
+++ b/src/chainlink/cleaning/cleaning_functions.py
@@ -24,6 +24,7 @@ from chainlink.cleaning.patterns import (
 from chainlink.cleaning.usps_suffixes import suffixes
 
 zip_cache: dict[str, dict[str, str]] = {}
+_search_engine = SearchEngine()
 
 state_names = [s.name for s in us.states.STATES_AND_TERRITORIES]
 state_abbr = [s.abbr for s in us.states.STATES_AND_TERRITORIES]
@@ -52,12 +53,7 @@ def predict_org(name: str) -> int:
     ):
         return 1
 
-    # Doing this because GX PROPERTY OWNER LLC exists
-    if re.search(individual_names, name):
-        return 0
-
-    else:
-        return 0
+    return 0
 
 
 def clean_zipcode(raw: str | int) -> str:
@@ -99,8 +95,7 @@ def identify_state_city(zipcode: str) -> tuple:
             return (zip_city, zip_state)
 
         else:
-            engine = SearchEngine()
-            zipcode_obj = engine.by_zipcode(int(zipcode))
+            zipcode_obj = _search_engine.by_zipcode(int(zipcode))
             # zip_cache[zipcode] = zipcode
 
             zip_city = zipcode_obj.major_city.upper()
@@ -280,7 +275,7 @@ def clean_address(raw: str) -> dict:
             record["unit_number"] = None
 
     # Overwrite city and state using uszip if the parsed state is not valid
-    if record["state"] not in state_abbr or record["state"] is None:
+    if record["state"] is None or record["state"] not in state_abbr:
         zip_city, zip_state = identify_state_city(record["postal_code"])
 
         # if don't find valid city, state, leave original
@@ -306,14 +301,10 @@ def clean_address(raw: str) -> dict:
         record["street_post_type"] = suffixes.get(record["street_post_type"])
 
     for key, value in record.items():
-        record[key] = None if value == "" else value
-
-    for k, v in record.items():
-        if v is None:
-            continue
-        # Force everything to a Python string:
-        if not isinstance(v, str):
-            record[k] = str(v)
+        if value == "":
+            record[key] = None
+        elif value is not None and not isinstance(value, str):
+            record[key] = str(value)
 
     return record
 
@@ -356,6 +347,4 @@ def clean_names(raw: str) -> str | None:
     name = re.sub(r"\s{2,}", " ", name)
     if (name == "") or (name == " "):
         return None
-    else:
-        return name
     return name

--- a/src/chainlink/link/tfidf_utils.py
+++ b/src/chainlink/link/tfidf_utils.py
@@ -37,7 +37,7 @@ def superfast_tfidf(
     return matches_df
 
 
-def get_matches_df(sparse_matrix: csr_matrix, name_vector: np.ndarray, top: None = None) -> pl.DataFrame:
+def get_matches_df(sparse_matrix: csr_matrix, name_vector: np.ndarray) -> pl.DataFrame:
     """
     create a matches dataframe given matrix of ngrams
     references
@@ -45,26 +45,12 @@ def get_matches_df(sparse_matrix: csr_matrix, name_vector: np.ndarray, top: None
         name_vector - list of names to compare
         id_vector - id of distinct name from entities list
     """
-    non_zeros = sparse_matrix.nonzero()
-
-    sparserows = non_zeros[0]
-    sparsecols = non_zeros[1]
-
-    nr_matches = top if top else sparsecols.size
-
-    entity_a = np.empty([nr_matches], dtype=object)
-    entity_b = np.empty([nr_matches], dtype=object)
-    similarity = np.zeros(nr_matches)
-
-    for index in range(0, nr_matches):
-        entity_a[index] = name_vector[sparserows[index]]
-        entity_b[index] = name_vector[sparsecols[index]]
-        similarity[index] = sparse_matrix.data[index]
+    sparserows, sparsecols = sparse_matrix.nonzero()
 
     data = {
-        "entity_a": entity_a,
-        "entity_b": entity_b,
-        "similarity": similarity,
+        "entity_a": name_vector[sparserows],
+        "entity_b": name_vector[sparsecols],
+        "similarity": sparse_matrix.data,
     }
     df = pl.DataFrame(data).with_columns(
         pl.col("entity_a").hash().alias("id_a"), pl.col("entity_b").hash().alias("id_b")

--- a/src/chainlink/load/load_utils.py
+++ b/src/chainlink/load/load_utils.py
@@ -28,7 +28,6 @@ def load_to_db(df: pl.DataFrame, table_name: str, db_conn: DuckDBPyConnection, s
     -------
     None
     """
-    df = df
     query = f"""
             CREATE SCHEMA IF NOT EXISTS {schema};
             DROP TABLE IF EXISTS {schema}.{table_name};

--- a/src/chainlink/main.py
+++ b/src/chainlink/main.py
@@ -63,15 +63,11 @@ def chainlink(
                 no_names = False
                 table["name_cols_og"] = table["name_cols"]
                 table["name_cols"] = [x.lower().replace(" ", "_") for x in table["name_cols"]]
-            else:
-                table["name_cols"] = []
 
             if len(table["address_cols"]) > 0:
                 no_addresses = False
                 table["address_cols_og"] = table["address_cols"]
                 table["address_cols"] = [x.lower().replace(" ", "_") for x in table["address_cols"]]
-            else:
-                table["address_cols"] = []
 
             table["id_col_og"] = table["id_col"]
             table["id_col"] = table["id_col"].lower().replace(" ", "_")
@@ -88,26 +84,16 @@ def chainlink(
         update_config(db_path, config, config_path)
         return True
 
-    bad_address_path = config["options"].get("bad_address_path", None)
-    bad_name_path = config["options"].get("bad_name_path", None)
-
-    if bad_address_path is not None:
+    def _load_bad_list(path: str | None) -> list:
+        if path is None:
+            return []
         try:
-            bad_addresses_df = pl.read_csv(bad_address_path)
-            bad_addresses = bad_addresses_df[:, 0].to_list()
+            return pl.read_csv(path)[:, 0].to_list()
         except Exception:
-            bad_addresses = []
-    else:
-        bad_addresses = []
+            return []
 
-    if bad_name_path is not None:
-        try:
-            bad_names_df = pl.read_csv(bad_name_path)
-            bad_names = bad_names_df[:, 0].to_list()
-        except Exception:
-            bad_names = []
-    else:
-        bad_names = []
+    bad_addresses = _load_bad_list(config["options"].get("bad_address_path"))
+    bad_names = _load_bad_list(config["options"].get("bad_name_path"))
 
     # list of link exclusions
 
@@ -120,6 +106,7 @@ def chainlink(
         df_db_columns = con.sql("show all tables").pl()
 
     schemas = config["schemas"]
+    schemas_by_name = {s["schema_name"]: s for s in schemas}
     new_schemas = []
 
     # load each schema. if schema is a new entity, create links
@@ -135,7 +122,7 @@ def chainlink(
 
     # load in all new schemas
     for new_schema in new_schemas:
-        schema_config = [schema for schema in schemas if schema["schema_name"] == new_schema][0]
+        schema_config = schemas_by_name[new_schema]
 
         with console.status(f"[bold yellow] Working on loading {new_schema}") as status:
             # load schema
@@ -180,7 +167,7 @@ def chainlink(
 
         # create tfidf links within each new schema
         for new_schema in new_schemas:
-            schema_config = [schema for schema in schemas if schema["schema_name"] == new_schema][0]
+            schema_config = schemas_by_name[new_schema]
 
             if probabilistic:
                 with console.status(f"[bold yellow] Working on fuzzy matching links in {new_schema}") as status:
@@ -193,13 +180,11 @@ def chainlink(
             # also create across links for each new schema
             existing_schemas = [schema for schema in schemas if schema["schema_name"] != new_schema]
 
-            new_schema_config = [schema for schema in schemas if schema["schema_name"] == new_schema][0]
-
             # make sure we havent already created this link combo
             for schema in existing_schemas:
-                if sorted(new_schema + schema["schema_name"]) not in created_schemas:
-                    links.append((new_schema_config, schema))
-                    created_schemas.append(sorted(new_schema + schema["schema_name"]))
+                if sorted([new_schema, schema["schema_name"]]) not in created_schemas:
+                    links.append((schema_config, schema))
+                    created_schemas.append(sorted([new_schema, schema["schema_name"]]))
 
         # across links for each new_schema, link across to all existing entities
         for new_schema_config, existing_schema in links:

--- a/src/chainlink/utils.py
+++ b/src/chainlink/utils.py
@@ -248,8 +248,7 @@ def create_config() -> dict:
                 break
             else:  # invalid config
                 # print(validate_config(config))
-                create_config_path = Prompt.ask("[red]> Invalid config. Please enter a valid yaml config")
-                create_config_path = input().strip()
+                create_config_path = Prompt.ask("[red]> Invalid config. Please enter a valid yaml config").strip()
                 config = load_config(create_config_path)
 
         return config
@@ -280,7 +279,7 @@ def create_config() -> dict:
         )
 
         if not config["options"]["load_only"]:
-            config["options"]["probablistic"] = Confirm.ask(
+            config["options"]["probabilistic"] = Confirm.ask(
                 "[green]> Run probabilisitic name and address matching?",
                 show_default=True,
                 default=False,
@@ -300,8 +299,7 @@ def create_config() -> dict:
         bad_address_path = bad_address_path.strip()
         if bad_address_path:
             while not os.path.exists(bad_address_path):
-                console.print("> Bad address path does not exist. Please enter a valid path or leave blank:")
-                bad_address_path = input().strip()
+                bad_address_path = Prompt.ask("[red]> Bad address path does not exist. Please enter a valid path or leave blank").strip()
             config["options"]["bad_address_path"] = bad_address_path
 
         add_schema = Confirm.ask("[green]> Add a new schema?", default=True, show_default=True)

--- a/src/chainlink/utils.py
+++ b/src/chainlink/utils.py
@@ -299,7 +299,9 @@ def create_config() -> dict:
         bad_address_path = bad_address_path.strip()
         if bad_address_path:
             while not os.path.exists(bad_address_path):
-                bad_address_path = Prompt.ask("[red]> Bad address path does not exist. Please enter a valid path or leave blank").strip()
+                bad_address_path = Prompt.ask(
+                    "[red]> Bad address path does not exist. Please enter a valid path or leave blank"
+                ).strip()
             config["options"]["bad_address_path"] = bad_address_path
 
         add_schema = Confirm.ask("[green]> Add a new schema?", default=True, show_default=True)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -45,10 +45,9 @@ CONFIG_SIMPLE_CREATE = {
         "update_config_only": False,
         "link_exclusions": [],
         "bad_address_path": None,
-        "probabilistic": False,
+        "probabilistic": True,
         "load_only": False,
         "db_path": "db/linked.db",
-        "probablistic": True,
     },
     "schemas": [
         {


### PR DESCRIPTION
## Summary

- **Correctness bug** (`main.py`): `sorted()` was called on the *concatenation* of two schema name strings (sorting individual characters), causing incorrect deduplication of cross-schema link pairs — fixed to `sorted([a, b])`
- **Silent bug** (`utils.py`): typo `"probablistic"` meant the interactive config builder always set the wrong key, so probabilistic matching was never enabled via interactive setup
- **Efficiency** (`cleaning_functions.py`): `SearchEngine()` (uszipcode DB connection) was instantiated on every cache miss; moved to a module-level singleton
- **Efficiency** (`tfidf_utils.py`): replaced Python `for` loop in `get_matches_df` with numpy vectorized indexing; removed dead `top` parameter
- **Simplification** (`main.py`): extracted `_load_bad_list()` helper to replace two identical try/except CSV loading blocks; built `schemas_by_name` dict to replace repeated O(n) list-comprehension lookups; removed redundant `else` branches
- **Quality** (`utils.py`): replaced bare `input()` calls with `Prompt.ask` for consistency with the Rich abstraction used throughout
- **Dead code removed**: unreachable `return`, `df = df` no-op, `predict_org` if/else where both branches returned `0`, and a redundant schema lookup
- **Minor fixes**: `None`-check order in `clean_address`, merged two sequential `record.items()` loops

## Test plan

- [x] `uv run pytest` — all 32 tests pass
- [ ] Verify interactive config builder now correctly sets `probabilistic: True` when user answers yes
- [ ] Verify cross-schema link deduplication works correctly with multi-schema configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)